### PR TITLE
[fix] Add Cleaner pattern to BotanMessageDigest for automatic native …

### DIFF
--- a/src/test/java/net/randombit/botan/digest/BotanMessageDigestTest.java
+++ b/src/test/java/net/randombit/botan/digest/BotanMessageDigestTest.java
@@ -29,6 +29,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.StringFormattedMessage;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.mockito.MockedStatic;
 
 @DisplayName("Botan message digest tests")
 public class BotanMessageDigestTest {


### PR DESCRIPTION
…resource cleanup

Implement automatic cleanup of native Botan hash objects using Java's Cleaner API to prevent memory leaks when MessageDigest instances are garbage collected.

Changes:
- Add Cleaner with HashCleanupAction to call botan_hash_destroy() on GC
- Register Cleaner in constructor
- Each MessageDigest instance gets independent cleanup registration

Unlike BotanMac (which has re-initialization triggering explicit cleanup), MessageDigest has no re-initialization method, so cleanup only occurs on garbage collection. This is safe because botan_hash_init() is only called once per instance lifetime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)