### PR TITLE
[docs] Update GitHub Actions badge links to filter by master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Botanj - Java Security Provider (JSP)
 > The code within this repository is currently in its early beta phase and has not been officially released.
 > We would strongly advise against using it for production purposes until it reaches a stable, release-ready state.
 
-[![ubuntu-build Actions Status](https://github.com/yaziza/botanj/workflows/ubuntu-build/badge.svg)](https://github.com/yaziza/botanj/actions)
+[![ubuntu-build Actions Status](https://github.com/yaziza/botanj/workflows/ubuntu-build/badge.svg)](https://github.com/yaziza/botanj/actions?branch=master)
 
-[![macos-build Actions Status](https://github.com/yaziza/botanj/workflows/macos-build/badge.svg)](https://github.com/yaziza/botanj/actions)
+[![macos-build Actions Status](https://github.com/yaziza/botanj/workflows/macos-build/badge.svg)](https://github.com/yaziza/botanj/actions?branch=master)
 
-[![codeql-analysis Actions Status](https://github.com/yaziza/botanj/workflows/codeql-analysis/badge.svg)](https://github.com/yaziza/botanj/actions)
+[![codeql-analysis Actions Status](https://github.com/yaziza/botanj/workflows/codeql-analysis/badge.svg)](https://github.com/yaziza/botanj/actions?branch=master)
 
 [![coverage](.github/badges/jacoco.svg)](https://github.com/yaziza/botanj/actions/workflows/code-coverage.yml)
 


### PR DESCRIPTION
Update CI badge links in README to include branch=master parameter, ensuring badges reflect the status of the master branch rather than all branches.