### PR TITLE
[bugfix] optimize array copying in engineUpdate() methods

### DIFF
--- a/src/main/java/net/randombit/botan/digest/BotanMessageDigest.java
+++ b/src/main/java/net/randombit/botan/digest/BotanMessageDigest.java
@@ -256,9 +256,9 @@ public class BotanMessageDigest extends MessageDigestSpi implements Cloneable {
 
   @Override
   protected void engineUpdate(byte[] input, int offset, int len) {
-    final byte[] bytes = Arrays.copyOfRange(input, offset, input.length);
+    final byte[] bytes = Arrays.copyOfRange(input, offset, Math.addExact(offset, len));
 
-    final int err = singleton().botan_hash_update(hashRef.getValue(), bytes, len);
+    final int err = singleton().botan_hash_update(hashRef.getValue(), bytes, bytes.length);
     checkNativeCall(err, "botan_hash_update");
 
     digestFinalized = false;

--- a/src/main/java/net/randombit/botan/mac/BotanMac.java
+++ b/src/main/java/net/randombit/botan/mac/BotanMac.java
@@ -223,14 +223,13 @@ public abstract class BotanMac extends MacSpi {
   @Override
   protected void engineInit(Key key, AlgorithmParameterSpec params) throws InvalidKeyException {
     final byte[] encodedKey = checkSecretKey(key);
-    final int length = encodedKey.length;
 
     // Clean up existing MAC object if re-initializing
     if (cleanable != null) {
       cleanable.clean();
     }
 
-    int err = singleton().botan_mac_init(macRef, getBotanMacName(length), 0);
+    int err = singleton().botan_mac_init(macRef, getBotanMacName(encodedKey.length), 0);
     checkNativeCall(err, "botan_mac_init");
 
     // Register cleaner for the newly created MAC object
@@ -241,9 +240,9 @@ public abstract class BotanMac extends MacSpi {
           return singleton().botan_mac_get_keyspec(a, b, c, d);
         };
 
-    checkKeySize(macRef.getValue(), length, getKeySpec);
+    checkKeySize(macRef.getValue(), encodedKey.length, getKeySpec);
 
-    err = singleton().botan_mac_set_key(macRef.getValue(), encodedKey, length);
+    err = singleton().botan_mac_set_key(macRef.getValue(), encodedKey, encodedKey.length);
     checkNativeCall(err, "botan_mac_set_key");
 
     currentKey = encodedKey;
@@ -260,9 +259,9 @@ public abstract class BotanMac extends MacSpi {
 
   @Override
   protected void engineUpdate(byte[] input, int offset, int len) {
-    final byte[] bytes = Arrays.copyOfRange(input, offset, input.length);
+    final byte[] bytes = Arrays.copyOfRange(input, offset, Math.addExact(offset, len));
 
-    final int err = singleton().botan_mac_update(macRef.getValue(), bytes, len);
+    final int err = singleton().botan_mac_update(macRef.getValue(), bytes, bytes.length);
     checkNativeCall(err, "botan_mac_update");
 
     macFinalized = false;


### PR DESCRIPTION
Correct Arrays.copyOfRange bounds in BotanMessageDigest and BotanMac to copy only requested bytes instead of copying to end of input array.

Changes input.length to offset + len, eliminating unnecessary memory allocation and copying for operations with non-zero offsets.

No functional change - cryptographic outputs remain correct. Performance improvement for offset-based update operations.